### PR TITLE
Add Axum activity feed example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +222,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +266,7 @@ version = "0.3.0"
 dependencies = [
  "async-stream",
  "axum",
+ "chrono",
  "indexmap",
  "reqwest",
  "rocket",
@@ -732,6 +760,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,6 +1114,15 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_cpus"
@@ -2349,6 +2410,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ axum = { version = "0.8.4", default-features = false, optional = true, features 
     "tokio",
     "json",
 ] }
+chrono = { version = "0.4.41", default-features = false, features = ["clock"] }
 rocket = { version = "0.5.1", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true, features = [
     "derive",

--- a/examples/activity-feed.html
+++ b/examples/activity-feed.html
@@ -13,21 +13,10 @@
             class="bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 rounded-lg px-6 py-8 ring shadow-xl ring-gray-900/5 space-y-2"
         >
             <div class="flex justify-between items-center">
-                <h1
-                    class="text-gray-900 dark:text-white text-3xl font-semibold"
-                >
-                    Datastar SDK Activity Feed Demo
-                </h1>
-                <img
-                    src="https://data-star.dev/static/images/rocket-64x64.png"
-                    alt="Rocket"
-                    width="64"
-                    height="64"
-                />
+                <h1 class="text-gray-900 dark:text-white text-3xl font-semibold">Datastar SDK Activity Feed Demo</h1>
+                <img src="https://data-star.dev/static/images/rocket-64x64.png" alt="Rocket" width="64" height="64" />
             </div>
-            <p class="mt-2">
-                SSE events will be streamed from the backend to the frontend.
-            </p>
+            <p class="mt-2">SSE events will be streamed from the backend to the frontend.</p>
             <div class="space-x-2">
                 <input
                     id="events"
@@ -91,32 +80,20 @@
                 Info
             </button>
         </div>
-        <div
-            class="mt-2 text-gray-400 font-mono text-sm rounded-md bg-black p-4"
-        >
+        <div class="mt-2 text-gray-400 font-mono text-sm rounded-md bg-black p-4">
             <div id="feed">
                 Click <code class="text-fuchsia-600">Generate</code> to create
-                <span data-text="$events">200</span> events,
-                <span data-text="$interval">10</span> milliseconds apart.<br />
-                <span class="text-gray-100" data-signals-total="0">
-                    Total: <span data-text="$total">0</span>
-                </span>
+                <span data-text="$events">200</span> events, <span data-text="$interval">10</span> milliseconds
+                apart.<br />
+                <span class="text-gray-100" data-signals-total="0"> Total: <span data-text="$total">0</span> </span>
                 |
-                <span class="text-green-500" data-signals-done="0">
-                    Done: <span data-text="$done">0</span>
-                </span>
+                <span class="text-green-500" data-signals-done="0"> Done: <span data-text="$done">0</span> </span>
                 |
-                <span class="text-yellow-500" data-signals-warn="0">
-                    Warn: <span data-text="$warn">0</span>
-                </span>
+                <span class="text-yellow-500" data-signals-warn="0"> Warn: <span data-text="$warn">0</span> </span>
                 |
-                <span class="text-red-500" data-signals-fail="0">
-                    Fail: <span data-text="$fail">0</span>
-                </span>
+                <span class="text-red-500" data-signals-fail="0"> Fail: <span data-text="$fail">0</span> </span>
                 |
-                <span class="text-blue-500" data-signals-info="0">
-                    Info: <span data-text="$info">0</span>
-                </span>
+                <span class="text-blue-500" data-signals-info="0"> Info: <span data-text="$info">0</span> </span>
                 <br />
                 -------------------------------------------------------------
             </div>

--- a/examples/activity-feed.html
+++ b/examples/activity-feed.html
@@ -10,14 +10,6 @@
     </head>
     <body class="bg-white dark:bg-gray-900 text-lg max-w-xl mx-auto my-16">
         <div
-            data-signals-interval="10"
-            data-signals-events="200"
-            data-signals-generating="false"
-            data-signals-total="0"
-            data-signals-done="0"
-            data-signals-warn="0"
-            data-signals-fail="0"
-            data-signals-info="0"
             class="bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 rounded-lg px-6 py-8 ring shadow-xl ring-gray-900/5 space-y-2"
         >
             <div class="flex justify-between items-center">
@@ -38,19 +30,21 @@
             </p>
             <div class="space-x-2">
                 <input
+                    id="events"
+                    data-signals-events="200"
                     data-bind-events
-                    id="count"
                     type="number"
                     step="100"
                     min="0"
                     class="w-36 rounded-md border border-gray-300 px-3 py-2 placeholder-gray-400 shadow-sm focus:border-sky-500 focus:outline focus:outline-sky-500 dark:disabled:border-gray-700 dark:disabled:bg-gray-800/20"
                 />
-                <label for="count"> Number of events </label>
+                <label for="events"> Number of events </label>
             </div>
             <div class="space-x-2">
                 <input
-                    data-bind-interval
                     id="interval"
+                    data-signals-interval="10"
+                    data-bind-interval
                     type="number"
                     step="10"
                     min="0"
@@ -61,9 +55,13 @@
             <button
                 id="start-button"
                 data-on-click="@post(&#39;/event/generate&#39;)"
+                data-signals-generating="false"
                 data-attr-disabled="$generating"
-                data-style-background-color="$generating && 'bg-gray-500'"
-                class="rounded-md px-5 py-2.5 leading-5 font-semibold text-white bg-sky-500 hover:bg-sky-700 hover:text-gray-100 cursor-pointer"
+                data-class="{
+                    'bg-gray-500 text-gray-300 cursor-wait': $generating,
+                    'bg-sky-500 text-white cursor-pointer hover:bg-sky-700 hover:text-gray-100': !$generating,
+                }"
+                class="rounded-md px-5 py-2.5 leading-5 font-semibold"
             >
                 Generate
             </button>
@@ -100,23 +98,23 @@
                 Click <code class="text-fuchsia-600">Generate</code> to create
                 <span data-text="$events">200</span> events,
                 <span data-text="$interval">10</span> milliseconds apart.<br />
-                <span class="text-gray-100">
+                <span class="text-gray-100" data-signals-total="0">
                     Total: <span data-text="$total">0</span>
                 </span>
                 |
-                <span class="text-green-500">
+                <span class="text-green-500" data-signals-done="0">
                     Done: <span data-text="$done">0</span>
                 </span>
                 |
-                <span class="text-yellow-500">
+                <span class="text-yellow-500" data-signals-warn="0">
                     Warn: <span data-text="$warn">0</span>
                 </span>
                 |
-                <span class="text-red-500"
-                    >Fail: <span data-text="$fail">0</span>
+                <span class="text-red-500" data-signals-fail="0">
+                    Fail: <span data-text="$fail">0</span>
                 </span>
                 |
-                <span class="text-blue-500">
+                <span class="text-blue-500" data-signals-info="0">
                     Info: <span data-text="$info">0</span>
                 </span>
                 <br />

--- a/examples/activity-feed.html
+++ b/examples/activity-feed.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <title>Datastar SDK Activity Feed Demo</title>
+        <script src="https://unpkg.com/@tailwindcss/browser@4"></script>
+        <script
+            type="module"
+            src="https://cdn.jsdelivr.net/gh/starfederation/datastar@main/bundles/datastar.js"
+        ></script>
+    </head>
+    <body class="bg-white dark:bg-gray-900 text-lg max-w-xl mx-auto my-16">
+        <div
+            data-signals-interval="10"
+            data-signals-events="200"
+            data-signals-generating="false"
+            class="bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 rounded-lg px-6 py-8 ring shadow-xl ring-gray-900/5 space-y-2"
+        >
+            <div class="flex justify-between items-center">
+                <h1
+                    class="text-gray-900 dark:text-white text-3xl font-semibold"
+                >
+                    Datastar SDK Activity Feed Demo
+                </h1>
+                <img
+                    src="https://data-star.dev/static/images/rocket-64x64.png"
+                    alt="Rocket"
+                    width="64"
+                    height="64"
+                />
+            </div>
+            <p class="mt-2">
+                SSE events will be streamed from the backend to the frontend.
+            </p>
+            <div class="space-x-2">
+                <input
+                    data-bind-events
+                    id="count"
+                    type="number"
+                    step="100"
+                    min="0"
+                    class="w-36 rounded-md border border-gray-300 px-3 py-2 placeholder-gray-400 shadow-sm focus:border-sky-500 focus:outline focus:outline-sky-500 dark:disabled:border-gray-700 dark:disabled:bg-gray-800/20"
+                />
+                <label for="count"> Number of events </label>
+            </div>
+            <div class="space-x-2">
+                <input
+                    data-bind-interval
+                    id="interval"
+                    type="number"
+                    step="10"
+                    min="0"
+                    class="w-36 rounded-md border border-gray-300 px-3 py-2 placeholder-gray-400 shadow-sm focus:border-sky-500 focus:outline focus:outline-sky-500 dark:disabled:border-gray-700 dark:disabled:bg-gray-800/20"
+                />
+                <label for="interval"> Interval in milliseconds </label>
+            </div>
+            <button
+                id="start-button"
+                data-on-click="@post(&#39;/event/generate&#39;)"
+                data-attr-disabled="$generating"
+                data-style-background-color="$generating && 'bg-gray-500'"
+                class="rounded-md px-5 py-2.5 leading-5 font-semibold text-white bg-sky-500 hover:bg-sky-700 hover:text-gray-100 cursor-pointer"
+            >
+                Generate
+            </button>
+            <span>&nbsp;|&nbsp;</span>
+            <button
+                data-on-click="@post(&#39;/event/done&#39;)"
+                class="rounded-md bg-sky-500 px-5 py-2.5 leading-5 font-semibold text-white hover:bg-sky-700 hover:text-gray-100 cursor-pointer"
+            >
+                Done
+            </button>
+            <button
+                data-on-click="@post(&#39;/event/warn&#39;)"
+                class="rounded-md bg-sky-500 px-5 py-2.5 leading-5 font-semibold text-white hover:bg-sky-700 hover:text-gray-100 cursor-pointer"
+            >
+                Warn
+            </button>
+            <button
+                data-on-click="@post(&#39;/event/fail&#39;)"
+                class="rounded-md bg-sky-500 px-5 py-2.5 leading-5 font-semibold text-white hover:bg-sky-700 hover:text-gray-100 cursor-pointer"
+            >
+                Fail
+            </button>
+            <button
+                data-on-click="@post(&#39;/event/info&#39;)"
+                class="rounded-md bg-sky-500 px-5 py-2.5 leading-5 font-semibold text-white hover:bg-sky-700 hover:text-gray-100 cursor-pointer"
+            >
+                Info
+            </button>
+        </div>
+        <div
+            class="mt-2 text-gray-400 font-mono text-sm rounded-md bg-black p-4"
+        >
+            <div id="feed">
+                Click <code class="text-fuchsia-600">Generate</code> to create
+                <span data-text="$events">200</span> events,
+                <span data-text="$interval">10</span> milliseconds apart.
+            </div>
+        </div>
+    </body>
+</html>

--- a/examples/activity-feed.html
+++ b/examples/activity-feed.html
@@ -13,6 +13,11 @@
             data-signals-interval="10"
             data-signals-events="200"
             data-signals-generating="false"
+            data-signals-total="0"
+            data-signals-done="0"
+            data-signals-warn="0"
+            data-signals-fail="0"
+            data-signals-info="0"
             class="bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 rounded-lg px-6 py-8 ring shadow-xl ring-gray-900/5 space-y-2"
         >
             <div class="flex justify-between items-center">
@@ -94,7 +99,28 @@
             <div id="feed">
                 Click <code class="text-fuchsia-600">Generate</code> to create
                 <span data-text="$events">200</span> events,
-                <span data-text="$interval">10</span> milliseconds apart.
+                <span data-text="$interval">10</span> milliseconds apart.<br />
+                <span class="text-gray-100">
+                    Total: <span data-text="$total">0</span>
+                </span>
+                |
+                <span class="text-green-500">
+                    Done: <span data-text="$done">0</span>
+                </span>
+                |
+                <span class="text-yellow-500">
+                    Warn: <span data-text="$warn">0</span>
+                </span>
+                |
+                <span class="text-red-500"
+                    >Fail: <span data-text="$fail">0</span>
+                </span>
+                |
+                <span class="text-blue-500">
+                    Info: <span data-text="$info">0</span>
+                </span>
+                <br />
+                -------------------------------------------------------------
             </div>
         </div>
     </body>

--- a/examples/axum-activity-feed.rs
+++ b/examples/axum-activity-feed.rs
@@ -1,0 +1,187 @@
+use {
+    async_stream::stream,
+    axum::{
+        Router,
+        response::{Html, IntoResponse, Sse},
+        routing::{get, post},
+    },
+    chrono,
+    core::{convert::Infallible, error::Error, time::Duration},
+    datastar::{
+        axum::ReadSignals,
+        prelude::{ElementPatchMode, PatchElements, PatchSignals},
+    },
+    serde::{Deserialize, Serialize},
+    std::sync::Arc,
+    tokio::sync::RwLock,
+    tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt},
+};
+
+pub struct State {
+    pub feed: Vec<String>,
+    pub count: Count,
+}
+
+pub struct Count {
+    pub all: u32,
+    pub done: u32,
+    pub warn: u32,
+    pub fail: u32,
+    pub info: u32,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                format!("{}=debug,tower_http=debug", env!("CARGO_CRATE_NAME")).into()
+            }),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let state = Arc::new(RwLock::new(State {
+        feed: Vec::new(),
+        count: Count {
+            all: 0,
+            done: 0,
+            warn: 0,
+            fail: 0,
+            info: 0,
+        },
+    }));
+
+    let state_generate = state.clone();
+    let state_info = state.clone();
+    let state_done = state.clone();
+    let state_warn = state.clone();
+    let state_fail = state.clone();
+
+    let event = { move |level, state| async move { event(level, state).await } };
+    let generate = { move |signals| async move { generate(signals, state_generate).await } };
+
+    let app = Router::new()
+        .route("/", get(index))
+        .route("/event/generate", post(generate))
+        .route("/event/info", post(move || event(Status::Info, state_info)))
+        .route("/event/done", post(move || event(Status::Done, state_done)))
+        .route("/event/warn", post(move || event(Status::Warn, state_warn)))
+        .route("/event/fail", post(move || event(Status::Fail, state_fail)));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
+        .await
+        .unwrap();
+
+    tracing::debug!("listening on {}", listener.local_addr().unwrap());
+
+    axum::serve(listener, app).await.unwrap();
+
+    Ok(())
+}
+
+async fn index() -> Html<&'static str> {
+    Html(include_str!("activity-feed.html"))
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Signals {
+    pub interval: u64,
+    pub events: u64,
+    pub generating: bool,
+}
+
+#[derive(Clone, PartialEq, Eq, Deserialize)]
+pub enum Status {
+    Info,
+    Done,
+    Warn,
+    Fail,
+}
+
+async fn generate(
+    ReadSignals(signals): ReadSignals<Signals>,
+    state: Arc<RwLock<State>>,
+) -> impl IntoResponse {
+    Sse::new(stream! {
+        let elements = r#"<div id="feed"></div>"#.to_string();
+        let patch = PatchElements::new(elements);
+        let sse_event = patch.write_as_axum_sse_event();
+        yield Ok::<_, Infallible>(sse_event);
+
+        let signals_generating = serde_json::to_string(&Signals{
+            generating: true,
+            interval: signals.interval,
+            events: signals.events,
+        }).unwrap();
+        let patch = PatchSignals::new(signals_generating);
+        let sse_event = patch.write_as_axum_sse_event();
+        yield Ok::<_, Infallible>(sse_event);
+
+        for _ in 1..=signals.events {
+            let mut state = state.write().await;
+            let elements = event_entry(&mut state, &Status::Done, "Auto");
+            let patch = PatchElements::new(elements).selector("#feed").mode(ElementPatchMode::After);
+            let sse_event = patch.write_as_axum_sse_event();
+            yield Ok::<_, Infallible>(sse_event);
+            tokio::time::sleep(Duration::from_millis(signals.interval)).await;
+        }
+
+        let signals_done = serde_json::to_string(&Signals{
+            generating: false,
+            interval: signals.interval,
+            events: signals.events,
+        }).unwrap();
+        let patch = PatchSignals::new(signals_done);
+        let sse_event = patch.write_as_axum_sse_event();
+        yield Ok::<_, Infallible>(sse_event);
+    })
+}
+
+async fn event(status: Status, state: Arc<RwLock<State>>) -> impl IntoResponse {
+    Sse::new(stream! {
+        let mut state = state.write().await;
+        let elements = event_entry(&mut state, &status, "Manual");
+        let patch = PatchElements::new(elements).selector("#feed").mode(ElementPatchMode::After);
+        let sse_event = patch.write_as_axum_sse_event();
+
+        yield Ok::<_, Infallible>(sse_event);
+    })
+}
+
+fn event_entry(state: &mut State, status: &Status, prefix: &str) -> String {
+    state.count.all += 1;
+    let timestamp = chrono::Utc::now()
+        .format("%Y-%m-%d %H:%M:%S%.3f")
+        .to_string();
+    match status {
+        Status::Done => {
+            state.count.done += 1;
+            format!(
+                "<div id='event-{}' class='text-green-500'>{} [ ✅ Done ] {} event {}</div>",
+                state.count.all, timestamp, prefix, state.count.all
+            )
+        }
+        Status::Warn => {
+            state.count.warn += 1;
+            format!(
+                "<div id='event-{}' class='text-yellow-500'>{} [ ⚠️ Warn ] {} event {}</div>",
+                state.count.all, timestamp, prefix, state.count.all
+            )
+        }
+        Status::Fail => {
+            state.count.fail += 1;
+            format!(
+                "<div id='event-{}' class='text-red-500'>{} [ ❌ Fail ] {} event {}</div>",
+                state.count.all, timestamp, prefix, state.count.all
+            )
+        }
+        Status::Info => {
+            state.count.info += 1;
+            format!(
+                "<div id='event-{}' class='text-blue-500'>{} [ ℹ️ Info ] {} event {}</div>",
+                state.count.all, timestamp, prefix, state.count.all
+            )
+        }
+    }
+}

--- a/examples/axum-activity-feed.rs
+++ b/examples/axum-activity-feed.rs
@@ -12,23 +12,8 @@ use {
         prelude::{ElementPatchMode, PatchElements, PatchSignals},
     },
     serde::{Deserialize, Serialize},
-    std::sync::Arc,
-    tokio::sync::RwLock,
     tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt},
 };
-
-pub struct State {
-    pub feed: Vec<String>,
-    pub count: Count,
-}
-
-pub struct Count {
-    pub all: u32,
-    pub done: u32,
-    pub warn: u32,
-    pub fail: u32,
-    pub info: u32,
-}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -41,33 +26,25 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
-    let state = Arc::new(RwLock::new(State {
-        feed: Vec::new(),
-        count: Count {
-            all: 0,
-            done: 0,
-            warn: 0,
-            fail: 0,
-            info: 0,
-        },
-    }));
-
-    let state_generate = state.clone();
-    let state_info = state.clone();
-    let state_done = state.clone();
-    let state_warn = state.clone();
-    let state_fail = state.clone();
-
-    let event = { move |level, state| async move { event(level, state).await } };
-    let generate = { move |signals| async move { generate(signals, state_generate).await } };
-
     let app = Router::new()
         .route("/", get(index))
         .route("/event/generate", post(generate))
-        .route("/event/info", post(move || event(Status::Info, state_info)))
-        .route("/event/done", post(move || event(Status::Done, state_done)))
-        .route("/event/warn", post(move || event(Status::Warn, state_warn)))
-        .route("/event/fail", post(move || event(Status::Fail, state_fail)));
+        .route(
+            "/event/info",
+            post(move |signals| event(Status::Info, signals)),
+        )
+        .route(
+            "/event/done",
+            post(move |signals| event(Status::Done, signals)),
+        )
+        .route(
+            "/event/warn",
+            post(move |signals| event(Status::Warn, signals)),
+        )
+        .route(
+            "/event/fail",
+            post(move |signals| event(Status::Fail, signals)),
+        );
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
         .await
@@ -89,6 +66,11 @@ pub struct Signals {
     pub interval: u64,
     pub events: u64,
     pub generating: bool,
+    pub total: u64,
+    pub done: u64,
+    pub warn: u64,
+    pub fail: u64,
+    pub info: u64,
 }
 
 #[derive(Clone, PartialEq, Eq, Deserialize)]
@@ -99,38 +81,35 @@ pub enum Status {
     Fail,
 }
 
-async fn generate(
-    ReadSignals(signals): ReadSignals<Signals>,
-    state: Arc<RwLock<State>>,
-) -> impl IntoResponse {
+async fn generate(ReadSignals(signals): ReadSignals<Signals>) -> impl IntoResponse {
     Sse::new(stream! {
-        let elements = r#"<div id="feed"></div>"#.to_string();
-        let patch = PatchElements::new(elements);
-        let sse_event = patch.write_as_axum_sse_event();
-        yield Ok::<_, Infallible>(sse_event);
-
-        let signals_generating = serde_json::to_string(&Signals{
-            generating: true,
-            interval: signals.interval,
-            events: signals.events,
-        }).unwrap();
-        let patch = PatchSignals::new(signals_generating);
-        let sse_event = patch.write_as_axum_sse_event();
-        yield Ok::<_, Infallible>(sse_event);
-
+        let mut total = signals.total;
+        let mut done = signals.done;
         for _ in 1..=signals.events {
-            let mut state = state.write().await;
-            let elements = event_entry(&mut state, &Status::Done, "Auto");
+            total += 1;
+            done += 1;
+            let elements = event_entry(total, &Status::Done, "Auto");
             let patch = PatchElements::new(elements).selector("#feed").mode(ElementPatchMode::After);
             let sse_event = patch.write_as_axum_sse_event();
+            yield Ok::<_, Infallible>(sse_event);
+            let signals_generating = serde_json::to_string(&Signals{
+                generating: true,
+                total,
+                done,
+                ..signals
+            }).unwrap();
+            let patch = PatchSignals::new(signals_generating);
+            let sse_event = patch.write_as_axum_sse_event();
+
             yield Ok::<_, Infallible>(sse_event);
             tokio::time::sleep(Duration::from_millis(signals.interval)).await;
         }
 
         let signals_done = serde_json::to_string(&Signals{
             generating: false,
-            interval: signals.interval,
-            events: signals.events,
+            total,
+            done,
+            ..signals
         }).unwrap();
         let patch = PatchSignals::new(signals_done);
         let sse_event = patch.write_as_axum_sse_event();
@@ -138,49 +117,65 @@ async fn generate(
     })
 }
 
-async fn event(status: Status, state: Arc<RwLock<State>>) -> impl IntoResponse {
+async fn event(status: Status, ReadSignals(signals): ReadSignals<Signals>) -> impl IntoResponse {
     Sse::new(stream! {
-        let mut state = state.write().await;
-        let elements = event_entry(&mut state, &status, "Manual");
+        let total = signals.total + 1;
+        let mut done = signals.done;
+        let mut warn = signals.warn;
+        let mut fail = signals.fail;
+        let mut info = signals.info;
+        match status {
+            Status::Done => done += 1,
+            Status::Warn => warn += 1,
+            Status::Fail => fail += 1,
+            Status::Info => info += 1,
+        }
+        let elements = event_entry(total, &status, "Manual");
         let patch = PatchElements::new(elements).selector("#feed").mode(ElementPatchMode::After);
         let sse_event = patch.write_as_axum_sse_event();
-
         yield Ok::<_, Infallible>(sse_event);
+
+        let signals = serde_json::to_string(&Signals {
+            total,
+            done,
+            warn,
+            fail,
+            info,
+            ..signals
+        }).unwrap();
+        let patch = PatchSignals::new(signals);
+        let sse_signal = patch.write_as_axum_sse_event();
+        yield Ok::<_, Infallible>(sse_signal);
     })
 }
 
-fn event_entry(state: &mut State, status: &Status, prefix: &str) -> String {
-    state.count.all += 1;
+fn event_entry(index: u64, status: &Status, prefix: &str) -> String {
     let timestamp = chrono::Utc::now()
         .format("%Y-%m-%d %H:%M:%S%.3f")
         .to_string();
     match status {
         Status::Done => {
-            state.count.done += 1;
             format!(
                 "<div id='event-{}' class='text-green-500'>{} [ ✅ Done ] {} event {}</div>",
-                state.count.all, timestamp, prefix, state.count.all
+                index, timestamp, prefix, index
             )
         }
         Status::Warn => {
-            state.count.warn += 1;
             format!(
                 "<div id='event-{}' class='text-yellow-500'>{} [ ⚠️ Warn ] {} event {}</div>",
-                state.count.all, timestamp, prefix, state.count.all
+                index, timestamp, prefix, index
             )
         }
         Status::Fail => {
-            state.count.fail += 1;
             format!(
                 "<div id='event-{}' class='text-red-500'>{} [ ❌ Fail ] {} event {}</div>",
-                state.count.all, timestamp, prefix, state.count.all
+                index, timestamp, prefix, index
             )
         }
         Status::Info => {
-            state.count.info += 1;
             format!(
                 "<div id='event-{}' class='text-blue-500'>{} [ ℹ️ Info ] {} event {}</div>",
-                state.count.all, timestamp, prefix, state.count.all
+                index, timestamp, prefix, index
             )
         }
     }


### PR DESCRIPTION
Expanding on the "Hello World" example, this activity feed includes additional implementations.

From the `axum-activity-feed.html`:
1. Nine `data-signals`
2. Two `data-bind` for inputs
3. Four `data-on-click` buttons
4. A conditional `data-class` for disabled button styling
5. Seven dynamic `data-text` elements

From the `axum-activity-feed.rs`:
1. A multi-value `Signals` struct
2. A `Status` enum that is also used as an `extract::Path` [route property](https://docs.rs/axum/latest/axum/struct.Router.html#method.route)
3. A long-running `generate` function that emits a user-defined number of events to the SSE stream
4. An `event` function that emits a single signal/element pair

