### PR TITLE
feat: add support for namespace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "datastar"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "asynk-strim",
  "axum",
@@ -2382,7 +2382,7 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
-]
+]/
 
 [[package]]
 name = "tracing-log"

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -31,6 +31,7 @@ pub(crate) const ELEMENTS_DATALINE_LITERAL: &str = "elements";
 pub(crate) const USE_VIEW_TRANSITION_DATALINE_LITERAL: &str = "useViewTransition";
 pub(crate) const SIGNALS_DATALINE_LITERAL: &str = "signals";
 pub(crate) const ONLY_IF_MISSING_DATALINE_LITERAL: &str = "onlyIfMissing";
+pub(crate) const NAMESPACE_DATALINE_LITERAL: &str = "namespace";
 
 // #endregion
 
@@ -97,6 +98,28 @@ impl EventType {
         match self {
             Self::PatchElements => "datastar-patch-elements",
             Self::PatchSignals => "datastar-patch-signals",
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+/// The namespace in which elements are created
+pub enum NameSpace {
+    /// HTML namespace for standard HTML
+    #[default]
+    Html,
+    /// SVG namespace for SVG elements.
+    Svg,
+    /// MathML namespace for mathematical notation.
+    Mathml,
+}
+
+impl NameSpace {
+    pub(crate) const fn as_str(&self) -> &str {
+        match self {
+            NameSpace::Html => "html",
+            NameSpace::Svg => "svg",
+            NameSpace::Mathml => "mathml",
         }
     }
 }

--- a/src/patch_elements.rs
+++ b/src/patch_elements.rs
@@ -2,8 +2,7 @@
 
 use {
     crate::{
-        DatastarEvent,
-        consts::{self, ElementPatchMode},
+        consts::{self, ElementPatchMode, NameSpace}, DatastarEvent
     },
     core::time::Duration,
 };
@@ -30,6 +29,9 @@ pub struct PatchElements {
     pub mode: ElementPatchMode,
     /// Whether to use view transitions, if not provided the Datastar client side will default to `false`.
     pub use_view_transition: bool,
+    /// The namespace in which elements are created.
+    /// If not provided that Datastar client side will default to [`NameSpace::Html`]
+    pub namespace: NameSpace,
 }
 
 impl PatchElements {
@@ -42,6 +44,7 @@ impl PatchElements {
             selector: None,
             mode: ElementPatchMode::default(),
             use_view_transition: consts::DEFAULT_ELEMENTS_USE_VIEW_TRANSITIONS,
+            namespace: NameSpace::default(),
         }
     }
 
@@ -54,6 +57,7 @@ impl PatchElements {
             selector: Some(selector.into()),
             mode: ElementPatchMode::Remove,
             use_view_transition: consts::DEFAULT_ELEMENTS_USE_VIEW_TRANSITIONS,
+            namespace: NameSpace::default()
         }
     }
 
@@ -84,6 +88,12 @@ impl PatchElements {
     /// Sets the `use_view_transition` of the [`PatchElements`] event.
     pub fn use_view_transition(mut self, use_view_transition: bool) -> Self {
         self.use_view_transition = use_view_transition;
+        self
+    }
+
+    /// Sets the `namespace` of the [`PatchElements`] event.
+    pub fn namespace(mut self, namespace: NameSpace) -> Self {
+        self.namespace = namespace;
         self
     }
 
@@ -125,6 +135,10 @@ impl PatchElements {
                 consts::USE_VIEW_TRANSITION_DATALINE_LITERAL,
                 self.use_view_transition
             ));
+        }
+
+        if self.namespace != NameSpace::default() {
+            data.push(format!("{} {}", consts::NAMESPACE_DATALINE_LITERAL, self.namespace.as_str()))
         }
 
         if let Some(ref elements) = self.elements {


### PR DESCRIPTION
datastar client supports data: namespace html|svg|mathml, implemented in https://github.com/starfederation/datastar/pull/1108.

The Rust SDK didn't support this so if you try to patch SVGs into the DOM they in the HTML namespace, causing them to not be rendered.

- added an enum NameSpace
- added namespace field and method to PatchElements
- namespace dataline is only included if namespace is not HTML, matching the behavior of ElementPatchMode
 
